### PR TITLE
Update synthetic_data.ipynb

### DIFF
--- a/python/notebooks/synthetic_data/synthetic_data.ipynb
+++ b/python/notebooks/synthetic_data/synthetic_data.ipynb
@@ -242,7 +242,7 @@
    "outputs": [],
    "source": [
     "#Read inference results\n",
-    "results = ir.InferenceResult(bin_dir)"
+    "results = ir.InferenceResult('./')"
    ]
   },
   {


### PR DESCRIPTION
"results = ir.InferenceResult(bin_dir)" only works if bin_dir is the current working directory.